### PR TITLE
Work around a bug with inner class parsing in g++ 4.8.5

### DIFF
--- a/utils/diva_activity.cxx
+++ b/utils/diva_activity.cxx
@@ -36,7 +36,7 @@
 #include <arrows/kpf/yaml/kpf_canonical_io_adapter.h>
 namespace KPF = kwiver::vital::kpf;
 
-class diva_activity::pimpl
+class diva_activity_impl
 {
 public:
   std::string                                              activity_name;
@@ -57,12 +57,12 @@ const int TRACK_DOMAIN = 2;
 // The KPF activity object is complex, and requires an adapter.
 //
 
-struct diva_activity_adapter : public KPF::kpf_act_adapter< diva_activity::pimpl >
+struct diva_activity_adapter : public KPF::kpf_act_adapter< diva_activity_impl >
 {
   diva_activity_adapter() :
-    kpf_act_adapter< diva_activity::pimpl >(
+    kpf_act_adapter< diva_activity_impl >(
       // reads the canonical activity "a" into the user_activity "u"
-      [](const KPF::canonical::activity_t& a, diva_activity::pimpl& u) 
+      [](const KPF::canonical::activity_t& a, diva_activity_impl& u)
   {
     if(a.activity_id_domain != DIVA_DOMAIN)
       throw malformed_diva_packet_exception("activty domain must be " + DIVA_DOMAIN);
@@ -126,7 +126,7 @@ struct diva_activity_adapter : public KPF::kpf_act_adapter< diva_activity::pimpl
   },
 
       // converts a user_activity "a" into a canonical activity and returns it
-    [](const diva_activity::pimpl& u) 
+    [](const diva_activity_impl& u)
   {
     KPF::canonical::activity_t a;
     // set the name, ID, and domain
@@ -215,7 +215,7 @@ struct diva_activity_adapter : public KPF::kpf_act_adapter< diva_activity::pimpl
 
 diva_activity::diva_activity()
 {
-  _pimpl = new pimpl();
+  _pimpl = new diva_activity_impl();
 }
 diva_activity::~diva_activity()
 {

--- a/utils/diva_activity.h
+++ b/utils/diva_activity.h
@@ -32,6 +32,8 @@
 #include "diva_packet.h"
 #include <map>
 
+class diva_activity_impl;
+
 class DIVA_UTILS_EXPORT diva_activity : public diva_packet
 {
   friend struct diva_activity_adapter;
@@ -89,6 +91,5 @@ public:
 
   void write(std::ostream& os) const;
 private:
-  class pimpl;
-  pimpl* _pimpl;
+  diva_activity_impl* _pimpl;
 };

--- a/utils/diva_geometry.cxx
+++ b/utils/diva_geometry.cxx
@@ -37,16 +37,19 @@
 
 namespace KPF = kwiver::vital::kpf;
 
-class diva_geometry::pimpl
+class diva_geometry_impl
 {
-public:
+  friend class diva_geometry;
+  friend struct diva_bbox_adapter;
+  friend struct diva_poly_adapter;
+
   size_t          detection_id;
   size_t          track_id;
   size_t          frame_id;
   double          frame_time_s;
   double          frame_absolute_time_us;
   double          confidence;
-  bounding_box    bbox;
+  diva_geometry:: bounding_box    bbox;
   diva_source     source;
   diva_occlusion  occlusion;
   diva_evaluation evaluation;
@@ -54,38 +57,38 @@ public:
   std::vector<std::pair<size_t, size_t>> poly;
 };
 
-struct diva_bbox_adapter : public KPF::kpf_box_adapter< diva_geometry::pimpl >
+struct diva_bbox_adapter : public KPF::kpf_box_adapter< diva_geometry_impl >
 {
   diva_bbox_adapter() :
-    kpf_box_adapter< diva_geometry::pimpl >(
+    kpf_box_adapter< diva_geometry_impl >(
       // reads the canonical box "b" into the user_detection "d"
-      [](const KPF::canonical::bbox_t& b, diva_geometry::pimpl& d) {
+      [](const KPF::canonical::bbox_t& b, diva_geometry_impl& d) {
     d.bbox.x1 = b.x1;
     d.bbox.y1 = b.y1;
     d.bbox.x2 = b.x2;
     d.bbox.y2 = b.y2; },
 
       // converts a user_detection "d" into a canonical box and returns it
-      [](const diva_geometry::pimpl& d) {
+      [](const diva_geometry_impl& d) {
       return KPF::canonical::bbox_t(
         d.bbox.x1,d.bbox.y1,
         d.bbox.x2,d.bbox.y2); })
   {}
 };
 
-struct diva_poly_adapter : public KPF::kpf_poly_adapter< diva_geometry::pimpl >
+struct diva_poly_adapter : public KPF::kpf_poly_adapter< diva_geometry_impl >
 {
   diva_poly_adapter() :
-    kpf_poly_adapter< diva_geometry::pimpl >(
+    kpf_poly_adapter< diva_geometry_impl >(
       // reads the canonical box "b" into the user_detection "d"
-      [](const KPF::canonical::poly_t& b, diva_geometry::pimpl& d) {
+      [](const KPF::canonical::poly_t& b, diva_geometry_impl& d) {
       d.poly.clear();
       for (auto p : b.xy) 
       {
         d.poly.push_back(std::pair<double,double>(p.first,p.second));
       }},
       // converts a user_detection "d" into a canonical box and returns it
-      [](const diva_geometry::pimpl& d) {
+      [](const diva_geometry_impl& d) {
         KPF::canonical::poly_t p;
         // should check that d's vectors are the same length
         for (auto pair : d.poly) 
@@ -98,7 +101,7 @@ struct diva_poly_adapter : public KPF::kpf_poly_adapter< diva_geometry::pimpl >
 
 diva_geometry::diva_geometry()
 {
-  _pimpl = new pimpl();
+  _pimpl = new diva_geometry_impl();
 }
 diva_geometry::~diva_geometry()
 {

--- a/utils/diva_geometry.h
+++ b/utils/diva_geometry.h
@@ -31,10 +31,11 @@
 #pragma once
 #include "diva_packet.h"
 
+
+class diva_geometry_impl;
+
 class DIVA_UTILS_EXPORT diva_geometry : public diva_packet
 {
-  friend struct diva_bbox_adapter;
-  friend struct diva_poly_adapter;
 public:
   struct bounding_box
   {
@@ -109,6 +110,5 @@ public:
 
   void write(std::ostream& os) const;
 private:
-  class pimpl;
-  pimpl* _pimpl;
+  diva_geometry_impl* _pimpl;
 };


### PR DESCRIPTION

g++ 4.8.5 (the default complier on centos7) has a bug:

 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59482

...which prevented the inner 'pimpl' classes for diva_geometry and
diva_activity from compiling. This commit converts the pimpl classes
from inner to peer classes.

Tested on both g++ 4.8.5 (centos7) and apple-clang 7.0.2 (osx).